### PR TITLE
rm size method, a couple extend instances

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,4 +1,4 @@
-import {escape, isEmpty, isEqual, iteratee, result, uniqueId} from 'underscore';
+import {escape, isEqual, iteratee, result, uniqueId} from 'underscore';
 import {urlError, wrapError} from './utils.js';
 
 import Events from './events.js';
@@ -211,7 +211,7 @@ export default class Model {
   hasChanged(attr) {
     /* eslint-disable eqeqeq */
     if (attr == null) {
-      return !isEmpty(this.changed);
+      return !!Object.keys(this.changed || {}).length;
     }
     /* eslint-enable eqeqeq */
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,4 +1,4 @@
-import {extend, result, size} from 'underscore';
+import {extend, result} from 'underscore';
 
 import {getAjaxPrefilter} from './config.js';
 import {stringify} from 'qs';
@@ -79,7 +79,7 @@ const MIME_TYPE_DEFAULT = 'application/x-www-form-urlencoded; charset=UTF-8';
  * application/json body data.
  */
 export function ajax(options) {
-  var hasData = !!size(options.data),
+  var hasData = !!Object.keys(options.data || {}).length,
       hasBodyContent = !/^(?:GET|HEAD)$/.test(options.type) && hasData;
 
   if (options.type === 'GET' && hasData) {
@@ -90,29 +90,27 @@ export function ajax(options) {
 
   return window.fetch(
     options.url,
-    extend(
-      options,
-      extend({
-        method: options.type,
-        headers: extend(
-          {Accept: MIME_TYPE_JSON},
-          // mock jquery behavior here as we migrate off of it:
-          //  * only set contentType header if a write request and if there is body data
-          //  * default to x-www-form-urlencoded. Schmackbone will pass application/json
-          //    and JSON-stringify options.data for save/destroy calls, but we'll do
-          //    it here for our own POST requests via fetch calls that Schmackbone doesn't cover
-          hasBodyContent ? {'Content-Type': options.contentType || MIME_TYPE_DEFAULT} : {},
-          options.headers
-        )
+    {
+      ...options,
+      method: options.type,
+      headers: {
+        Accept: MIME_TYPE_JSON,
+        // mock jquery behavior here as we migrate off of it:
+        //  * only set contentType header if a write request and if there is body data
+        //  * default to x-www-form-urlencoded. Schmackbone will pass application/json
+        //    and JSON-stringify options.data for save/destroy calls, but we'll do
+        //    it here for our own POST requests via fetch calls that Schmackbone doesn't cover
+        ...hasBodyContent ? {'Content-Type': options.contentType || MIME_TYPE_DEFAULT} : {},
+        ...options.headers
       },
-      hasBodyContent ? {
+      ...hasBodyContent ? {
         body: typeof options.data === 'string' ?
           options.data :
           options.contentType === MIME_TYPE_JSON ?
             JSON.stringify(options.data) :
             stringify(options.data)
-      } : {})
-    )
+      } : {}
+    }
   ).then((res) => {
     // make a copy of the response object and place it into the options
     // `response` property we created before Schmackbone.sync. This will make it


### PR DESCRIPTION
Missed an instance of `_.size` that can be removed, as well as some (but not all) `_.extend` .