### PR TITLE
expose ajax method from sync module

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ export {setAjaxPrefilter} from './lib/config.js';
 export {default as Events} from './lib/events.js';
 export {default as History} from './lib/history.js';
 export {default as Model} from './lib/model.js';
-export {default as sync} from './lib/sync.js';
+export {default as sync, ajax} from './lib/sync.js';
 export {default as Router} from './lib/router.js';
 export {history} from './lib/history.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schmackbone",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "main": "index.js",
   "module": "index.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Makes the `ajax` (`window.fetch`) wrapper importable directly from the package.